### PR TITLE
fix not refresh screen in pcbnew after selecting layer/item-set

### DIFF
--- a/layerviewset.py
+++ b/layerviewset.py
@@ -471,8 +471,10 @@ class layerviewset(pcbnew.ActionPlugin):
         # The the visible layers according to that element in the stack.        
         if element[0] is not None:
             pcbnew.GetBoard().SetVisibleLayers(element[0])
+            pcbnew.Refresh()
         if element[1] is not None:
             pcbnew.GetBoard().SetVisibleElements(element[1])
+            pcbnew.Refresh()
         try:
             pcbnew.UpdateUserInterface()
             self._message.SetLabel(element[2].GetLabel())
@@ -678,8 +680,10 @@ class layerviewset(pcbnew.ActionPlugin):
                 # for num in range(board.PCB_LAYER_ID_COUNT):
                     # board.GetDesignSettings().SetLayerVisibility(num,False)
                 board.SetVisibleLayers(element[0])
+                pcbnew.Refresh()
             if element[1] is not None:
                 board.SetVisibleElements(element[1])
+                pcbnew.Refresh()
                 
             #for layer,cb in layercb.iteritems():
             #    cb.Value = board.IsLayerVisible(layer)


### PR DESCRIPTION
Hi Genius,

The LayerViewSet is a amazing plugin I have never seen!

Thanks to you, I ended up not needing to dive into the reference "Kicad Pcbnew Python Scripting".

However, there is a trivial problem that is not refresh screen after selecting layer/item-set until moving mouse pointer into work area in pcbnew under my environment.

So I tried to inject boring workaround for a change.
Sorry for my poor code, this change takes more time to refresh screen.

reproduction environment: 
  - Win 10
  - KiCAD (5.1.6)-1, release build 
  - modern toolset (accelerated and fallback)

thx.
